### PR TITLE
Cap FluentAssertions to Open Licence

### DIFF
--- a/JumpList.Test/JumpList.Test.csproj
+++ b/JumpList.Test/JumpList.Test.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="OleCf" Version="1.5.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
     <PackageReference Include="NUnit" Version="4.3.2" />  
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Due to the mess of [here](https://github.com/fluentassertions/fluentassertions/pull/2943). Protects against License Change 